### PR TITLE
[GI-3] - Adiciona testes para o módulo SendIssuesToWebhook

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -40,7 +40,7 @@ config :phoenix, :json_library, Jason
 
 config :git_issues, GitIssues.Scheduler,
   jobs: [
-    {"*/2 * * * *", {GitIssues.SendIssuesToWebhook, :call, []}}
+    {"0 * * * *", {GitIssues.SendIssuesToWebhook, :call, []}}
   ]
 
 # Import environment specific config. This must remain at the bottom

--- a/config/runtime.exs
+++ b/config/runtime.exs
@@ -52,8 +52,11 @@ if config_env() == :prod do
 
   config :git_issues, :github,
     client: GitIssues.Github.Client,
-    base_url: "https://api.github.com",
-    api_key: System.get_env("GITHUB_TOKEN") || "ghp_XXX"
+    webhook_client: GitIssues.Github.WebhookClient,
+    base_url: System.get_env("GITHUB_API_URL") || "https://api.github.com",
+    api_key: System.get_env("GITHUB_API_KEY") || raise("GITHUB_API_KEY is missing"),
+    webhook: "https://webhook.site/",
+    delay: 24
 
   # ## SSL Support
   #

--- a/lib/git_issues/github/webhook_client.ex
+++ b/lib/git_issues/github/webhook_client.ex
@@ -9,8 +9,6 @@ defmodule GitIssues.Github.WebhookClient do
     do: [{"Content-Type", "application/json"}]
 
   @impl true
-  def base_url, do: Application.get_env(:git_issues, :github)[:webhook_url]
 
-  @impl true
-  def process_response_body(body), do: Jason.decode!(body)
+  def process_response_body(body) when is_binary(body), do: body
 end

--- a/lib/git_issues/github/webhook_client.ex
+++ b/lib/git_issues/github/webhook_client.ex
@@ -1,0 +1,16 @@
+defmodule GitIssues.Github.WebhookClient do
+  @moduledoc """
+  Serviço responsável pela comunicação com API do  github
+  """
+  use GitIssues.Services, :behaviour
+
+  @impl true
+  def default_headers,
+    do: [{"Content-Type", "application/json"}]
+
+  @impl true
+  def base_url, do: Application.get_env(:git_issues, :github)[:webhook_url]
+
+  @impl true
+  def process_response_body(body), do: Jason.decode!(body)
+end

--- a/lib/git_issues/send_issues_to_webhook.ex
+++ b/lib/git_issues/send_issues_to_webhook.ex
@@ -21,7 +21,7 @@ defmodule GitIssues.SendIssuesToWebhook do
     |> Enum.each(fn {id, issue} ->
       if DateTime.diff(DateTime.utc_now(), issue.created_at, :hour) == delay_to_send_issue() do
         Logger.info("Issue #{id} created at #{issue.created_at} is ready to be sent to webhook")
-        spawn(fn -> send_issue(issue) end)
+        send_issue(issue)
         :ets.delete(:issues, id)
       end
     end)
@@ -32,14 +32,14 @@ defmodule GitIssues.SendIssuesToWebhook do
   defp send_issue(issue) do
     IO.puts("Sending issue to webhook ")
 
-    body = Jason.encode!(issue)
-
     webhook_url()
-    |> webhook_client().post!(body, [])
+    |> webhook_client().post!(issue, [])
   end
 
   defp delay_to_send_issue, do: Application.get_env(:git_issues, :github)[:delay]
 
   defp webhook_url, do: Application.get_env(:git_issues, :github)[:webhook_url]
-  defp webhook_client, do: Application.get_env(:git_issues, :github)[:webhook_client]
+
+  defp webhook_client,
+    do: Application.get_env(:git_issues, :github)[:webhook_client] |> IO.inspect()
 end

--- a/test/git_issues/send_issues_to_webhook_test.exs
+++ b/test/git_issues/send_issues_to_webhook_test.exs
@@ -1,11 +1,6 @@
 defmodule GitIssues.SendIssuesToWebhookTest do
   use ExUnit.Case, async: false
 
-  setup do
-    Application.put_env(:git_issues, :github, %{webhook_url: "http://example.com", delay: 24})
-    :ok
-  end
-
   test "sends issues to webhook" do
     issue_created_at =
       DateTime.utc_now()

--- a/test/git_issues/send_issues_to_webhook_test.exs
+++ b/test/git_issues/send_issues_to_webhook_test.exs
@@ -1,0 +1,21 @@
+defmodule GitIssues.SendIssuesToWebhookTest do
+  use ExUnit.Case, async: false
+
+  setup do
+    Application.put_env(:git_issues, :github, %{webhook_url: "http://example.com", delay: 24})
+    :ok
+  end
+
+  test "sends issues to webhook" do
+    issue_created_at =
+      DateTime.utc_now()
+      |> DateTime.add(-24, :hour)
+
+    issue = %{id: 1, created_at: issue_created_at, other_fields: "value"}
+    true = :ets.insert(:issues, {1, issue})
+
+    :ok = GitIssues.SendIssuesToWebhook.call()
+
+    assert :ets.lookup(:issues, 1) == []
+  end
+end

--- a/test/support/mocks/github/webhook_client.ex
+++ b/test/support/mocks/github/webhook_client.ex
@@ -1,0 +1,13 @@
+defmodule GitIssues.Mock.Github.WebhookClient do
+  @moduledoc false
+
+  use GitIssues.Services, :behaviour
+
+  def post!(_, _, _) do
+    {:ok,
+     %{
+       status_code: 200,
+       body: ""
+     }}
+  end
+end


### PR DESCRIPTION
Para testar de forma efetiva o módulo `SendIssuesToWebhook` foi necessário:

- [x] Criar um client para o webhook chamado `GitIssues.Github.WebhookClient`;
- [x] Mockar a chamada para o webhook através do `GitIssues.Mock.Github.WebhookClient`; 
- [x] Configurar envvar `webhook_client` para cada ambiente;

Dessa forma ao invés do módulo `SendIssuesToWebhook` chamar diretamente o HTTPoison, ele passa pelo módulo intermediário configurado para o ambiente que estiver rodando, por exemplo no ambiente de testes, o `GitIssues.Mock.Github.WebhookClient` que simula uma chamada para um webhook externo qualquer;